### PR TITLE
chore: changed `npm i` to `npm ci`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "./",
   "publicPath": "./",
   "scripts": {
-    "init": "npm i && cd webapp && npm run init",
+    "init": "npm ci && cd webapp && npm run init",
     "transpile": "tsc",
     "watch": "tsc -w",
     "start": "npm run init && npm run start:dev",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -10,7 +10,7 @@
   "homepage": "./",
   "publicPath": "./",
   "scripts": {
-    "init": "npm i",
+    "init": "npm ci",
     "test:watch": "jest --watchAll",
     "test": "jest --silent",
     "test:console": "jest",


### PR DESCRIPTION
When running _npm init_, it creates a new package-lock.json, updated to _npm ci_ so it will just install packages based on the existing packages.