### PR TITLE
fix: replaced data source of receiving addresses

### DIFF
--- a/webapp/src/containers/LiquidityPage/components/AddLiquidity/index.tsx
+++ b/webapp/src/containers/LiquidityPage/components/AddLiquidity/index.tsx
@@ -22,7 +22,6 @@ import {
 import { NavLink as RRNavLink } from 'react-router-dom';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import EllipsisText from 'react-ellipsis-text';
 
 import LiquidityCard from '../../../../components/LiquidityCard';
 import {
@@ -62,8 +61,8 @@ import Spinner from '../../../../components/Svg/Spinner';
 import BigNumber from 'bignumber.js';
 import openNewTab from '../../../../utils/openNewTab';
 import Header from '../../../HeaderComponent';
-import { getReceivingAddressAndAmountList } from '../../../TokensPage/service';
 import { handleFetchRegularDFI } from '../../../WalletPage/service';
+import { PaymentRequestModel } from '../../../WalletPage/components/ReceivePage/PaymentRequestList';
 
 interface AddLiquidityProps {
   location: any;
@@ -85,6 +84,7 @@ interface AddLiquidityProps {
   fetchUtxoDfiRequest: () => void;
   maxAccountDfi: number;
   fetchMaxAccountDfiRequest: () => void;
+  paymentRequests: PaymentRequestModel[];
 }
 
 const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
@@ -100,7 +100,6 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
   const [allowCalls, setAllowCalls] = useState<boolean>(false);
   const [liquidityChanged, setLiquidityChanged] = useState<boolean>(false);
   const [liquidityChangedMsg, setLiquidityChangedMsg] = useState<string>('');
-  const [receiveAddresses, setReceiveAddresses] = useState<any>([]);
   const [sufficientUtxos, setSufficientUtxos] = useState<boolean>(false);
 
   const [formState, setFormState] = useState<any>({
@@ -116,7 +115,6 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
     receiveLabel: '',
   });
   const {
-    poolshares,
     poolPairList,
     fetchPoolPairListRequest,
     tokenBalanceList,
@@ -129,10 +127,9 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
     walletBalance,
     isLoadingPreparingUTXO,
     isLoadingAddingLiquidity,
-    utxoDfi,
     fetchUtxoDfiRequest,
-    maxAccountDfi,
     fetchMaxAccountDfiRequest,
+    paymentRequests,
   } = props;
 
   useEffect(() => {
@@ -153,8 +150,6 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
 
   useEffect(() => {
     async function addressAndAmount() {
-      const data = await getReceivingAddressAndAmountList();
-      setReceiveAddresses(data.addressAndAmountList);
       const balanceSymbolMap: any = getBalanceAndSymbolMap(tokenBalanceList);
       if (idTokenA && idTokenB) {
         let balanceA;
@@ -176,8 +171,8 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
             hash1: idTokenA,
             symbol1: tokenA,
             balance1: balanceA,
-            receiveAddress: data.addressAndAmountList[0]?.address,
-            receiveLabel: data.addressAndAmountList[0]?.label,
+            receiveAddress: paymentRequests[0]?.address,
+            receiveLabel: paymentRequests[0]?.label,
           });
         } else if (!balanceA) {
           setFormState({
@@ -185,8 +180,8 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
             hash2: idTokenB,
             symbol2: tokenB,
             balance2: balanceB,
-            receiveAddress: data.addressAndAmountList[0]?.address,
-            receiveLabel: data.addressAndAmountList[0]?.label,
+            receiveAddress: paymentRequests[0]?.address,
+            receiveLabel: paymentRequests[0]?.label,
           });
         } else {
           setFormState({
@@ -197,8 +192,8 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
             symbol2: tokenB,
             balance1: balanceA,
             balance2: balanceB,
-            receiveAddress: data.addressAndAmountList[0]?.address,
-            receiveLabel: data.addressAndAmountList[0]?.label,
+            receiveAddress: paymentRequests[0]?.address,
+            receiveLabel: paymentRequests[0]?.label,
           });
         }
       } else {
@@ -210,8 +205,8 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
             hash1: DFI_SYMBOL,
             symbol1: DFI,
             balance1: balanceA,
-            receiveAddress: data.addressAndAmountList[0]?.address,
-            receiveLabel: data.addressAndAmountList[0]?.label,
+            receiveAddress: paymentRequests[0]?.address,
+            receiveLabel: paymentRequests[0]?.label,
           });
         } else {
           setFormState({
@@ -222,8 +217,8 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
             symbol2: BTC,
             balance1: balanceA,
             balance2: balanceB,
-            receiveAddress: data.addressAndAmountList[0]?.address,
-            receiveLabel: data.addressAndAmountList[0]?.label,
+            receiveAddress: paymentRequests[0]?.address,
+            receiveLabel: paymentRequests[0]?.label,
           });
         }
       }
@@ -504,7 +499,11 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
   };
 
   const getTransactionLabel = (formState: any) => {
-    return getTransactionAddressLabel(formState.receiveLabel, formState.receiveAddress, I18n.t('containers.swap.addLiquidity.receiveAddress'));
+    return getTransactionAddressLabel(
+      formState.receiveLabel,
+      formState.receiveAddress,
+      I18n.t('containers.swap.addLiquidity.receiveAddress')
+    );
   };
 
   return (
@@ -595,7 +594,7 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
                       </Col>
                     </Row>
                   </DropdownItem>
-                  {receiveAddresses.map((data) => {
+                  {paymentRequests.map((data) => {
                     return (
                       <DropdownItem
                         className='justify-content-between ml-0 w-100'
@@ -929,7 +928,7 @@ const mapStateToProps = (state) => {
     utxoDfi,
     maxAccountDfi,
   } = state.swap;
-  const { walletBalance } = state.wallet;
+  const { walletBalance, paymentRequests } = state.wallet;
   return {
     poolPairList,
     tokenBalanceList,
@@ -943,6 +942,7 @@ const mapStateToProps = (state) => {
     isLoadingAddingLiquidity,
     utxoDfi,
     maxAccountDfi,
+    paymentRequests,
   };
 };
 

--- a/webapp/src/containers/TokensPage/components/CreateToken/index.tsx
+++ b/webapp/src/containers/TokensPage/components/CreateToken/index.tsx
@@ -16,6 +16,7 @@ import {
   MINIMUM_DFI_REQUIRED_FOR_TOKEN_CREATION,
 } from '../../../../constants';
 import { ITokenResponse } from '../../../../utils/interfaces';
+import { PaymentRequestModel } from '../../../WalletPage/components/ReceivePage/PaymentRequestList';
 
 interface RouteParams {
   id?: string;
@@ -32,13 +33,13 @@ interface CreateTokenProps extends RouteComponentProps<RouteParams> {
   isErrorUpdatingToken: string;
   isTokenCreating: boolean;
   isErrorCreatingToken: string;
+  paymentRequests: PaymentRequestModel[];
 }
 
 const CreateToken: React.FunctionComponent<CreateTokenProps> = (
   props: CreateTokenProps
 ) => {
   const { id } = props.match.params;
-  const [collateralAddresses, setCollateralAddresses] = useState<any>([]);
   const [activeTab, setActiveTab] = useState<string>(CREATE_DCT);
   const [IsCollateralAddressValid, setIsCollateralAddressValid] = useState<
     boolean
@@ -52,7 +53,7 @@ const CreateToken: React.FunctionComponent<CreateTokenProps> = (
     mintable: 'true',
     tradeable: 'true',
     collateralAddress: '',
-    collateralLabel: ''
+    collateralLabel: '',
   });
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState<
     string
@@ -95,16 +96,15 @@ const CreateToken: React.FunctionComponent<CreateTokenProps> = (
     isErrorCreatingToken,
     isTokenUpdating,
     isErrorUpdatingToken,
+    paymentRequests,
   } = props;
 
   useEffect(() => {
     async function addressAndAmount() {
-      const data = await getReceivingAddressAndAmountList();
-      setCollateralAddresses(data.addressAndAmountList);
       setFormState({
         ...formState,
-        collateralAddress: data.addressAndAmountList[0]?.address,
-        collateralLabel: data.addressAndAmountList[0]?.label
+        collateralAddress: paymentRequests[0]?.address,
+        collateralLabel: paymentRequests[0]?.label,
       });
     }
     addressAndAmount();
@@ -162,7 +162,7 @@ const CreateToken: React.FunctionComponent<CreateTokenProps> = (
     } else {
       setFormState({
         ...formState,
-        ...newData
+        ...newData,
       });
       setIsCollateralAddressValid(true);
     }
@@ -203,7 +203,7 @@ const CreateToken: React.FunctionComponent<CreateTokenProps> = (
             isUpdate={!isEmpty(tokenInfo) && !!id}
             handleChange={handleChange}
             formState={formState}
-            collateralAddresses={collateralAddresses}
+            collateralAddresses={paymentRequests}
             isErrorCreatingToken={isErrorCreatingToken}
             createdTokenData={createdTokenData}
             updatedTokenData={updatedTokenData}
@@ -239,7 +239,7 @@ const CreateToken: React.FunctionComponent<CreateTokenProps> = (
 };
 
 const mapStateToProps = (state) => {
-  const { tokens } = state;
+  const { tokens, wallet } = state;
   return {
     tokenInfo: tokens.tokenInfo,
     isTokenCreating: tokens.isTokenCreating,
@@ -248,6 +248,7 @@ const mapStateToProps = (state) => {
     isTokenUpdating: tokens.isTokenUpdating,
     updatedTokenData: tokens.updatedTokenData,
     isErrorUpdatingToken: tokens.isErrorUpdatingToken,
+    paymentRequests: wallet.paymentRequests,
   };
 };
 

--- a/webapp/src/containers/WalletPage/__tests__/services.test.tsx
+++ b/webapp/src/containers/WalletPage/__tests__/services.test.tsx
@@ -20,9 +20,9 @@ import * as Utility from '../../../utils/utility';
 import { MAINNET } from '../../../constants';
 const networkName = MAINNET.toLowerCase();
 describe('Wallet page service unit test', () => {
-  it('should check for handelGetPaymentRequest', () => {
+  it('should check for handleGetPaymentRequest', () => {
     const PersistentStore = mockPersistentStore(null, null);
-    service.handelGetPaymentRequest(networkName);
+    service.handleGetPaymentRequest(networkName);
     expect(PersistentStore.get).toBeCalledTimes(1);
   });
 

--- a/webapp/src/containers/WalletPage/components/ReceivePage/PaymentRequestList/index.tsx
+++ b/webapp/src/containers/WalletPage/components/ReceivePage/PaymentRequestList/index.tsx
@@ -23,16 +23,18 @@ import QrCode from '../../../../../components/QrCode';
 import CopyToClipboard from '../../../../../components/CopyToClipboard';
 import Pagination from '../../../../../components/Pagination';
 
+export interface PaymentRequestModel {
+  label: string;
+  id: string;
+  time: string;
+  address: string;
+  message?: string;
+  amount?: number;
+  unit?: string;
+}
+
 interface PaymentRequestsProps {
-  paymentRequests: {
-    label: string;
-    id: string;
-    time: string;
-    address: string;
-    message: string;
-    amount: number;
-    unit: string;
-  }[];
+  paymentRequests: PaymentRequestModel[];
   removeReceiveTxns: (id: string | number) => void;
 }
 

--- a/webapp/src/containers/WalletPage/saga.tsx
+++ b/webapp/src/containers/WalletPage/saga.tsx
@@ -66,7 +66,6 @@ import {
   importPrivKey,
   getListAccountHistory,
   handleRestartCriteria,
-  handleGetReceivedAddress,
 } from './service';
 import store from '../../app/rootStore';
 import showNotification from '../../utils/notifications';
@@ -174,7 +173,8 @@ export function* removeReceiveTxns(action: any) {
 
 export function* fetchPayments() {
   try {
-    const data = yield call(handleGetReceivedAddress);
+    const networkName = yield call(getNetwork);
+    const data = yield call(handleGetPaymentRequest, networkName);
     const list = yield all(
       data.map((item) => {
         item.id = item.id ?? uid();

--- a/webapp/src/containers/WalletPage/saga.tsx
+++ b/webapp/src/containers/WalletPage/saga.tsx
@@ -51,7 +51,7 @@ import {
 } from './reducer';
 import {
   handleFetchTokens,
-  handelGetPaymentRequest,
+  handleGetPaymentRequest,
   handelAddReceiveTxns,
   handelFetchWalletTxns,
   handleSendData,
@@ -66,6 +66,7 @@ import {
   importPrivKey,
   getListAccountHistory,
   handleRestartCriteria,
+  handleGetReceivedAddress,
 } from './service';
 import store from '../../app/rootStore';
 import showNotification from '../../utils/notifications';
@@ -93,6 +94,7 @@ import PersistentStore from '../../utils/persistentStore';
 import { createMnemonicIpcRenderer } from '../../app/update.ipcRenderer';
 import minBy from 'lodash/minBy';
 import orderBy from 'lodash/orderBy';
+import uid from 'uid';
 
 export function* getNetwork() {
   const {
@@ -172,10 +174,12 @@ export function* removeReceiveTxns(action: any) {
 
 export function* fetchPayments() {
   try {
-    const networkName = yield call(getNetwork);
-    const data = yield call(handelGetPaymentRequest, networkName);
+    const data = yield call(handleGetReceivedAddress);
     const list = yield all(
-      data.map((item) => call(getAddressInfo, item.address))
+      data.map((item) => {
+        item.id = item.id ?? uid();
+        return call(getAddressInfo, item.address);
+      })
     );
     const result = data.filter((item) => {
       const found = list.find(

--- a/webapp/src/containers/WalletPage/service.tsx
+++ b/webapp/src/containers/WalletPage/service.tsx
@@ -28,6 +28,7 @@ import {
   getRandomWordObject,
 } from '../../utils/utility';
 import BigNumber from 'bignumber.js';
+import { PaymentRequestModel } from './components/ReceivePage/PaymentRequestList';
 
 const handleLocalStorageName = (networkName) => {
   if (networkName === BLOCKCHAIN_INFO_CHAIN_TEST) {
@@ -36,10 +37,17 @@ const handleLocalStorageName = (networkName) => {
   return PAYMENT_REQUEST;
 };
 
-export const handelGetPaymentRequest = (networkName) => {
+export const handleGetPaymentRequest = (networkName) => {
   return JSON.parse(
     PersistentStore.get(handleLocalStorageName(networkName)) || '[]'
   );
+};
+
+export const handleGetReceivedAddress = async (): Promise<
+  PaymentRequestModel[]
+> => {
+  const rpcClient = new RpcClient();
+  return await rpcClient.getListreceivedAddress();
 };
 
 export const handelAddReceiveTxns = (data, networkName) => {

--- a/webapp/src/containers/WalletPage/service.tsx
+++ b/webapp/src/containers/WalletPage/service.tsx
@@ -28,7 +28,6 @@ import {
   getRandomWordObject,
 } from '../../utils/utility';
 import BigNumber from 'bignumber.js';
-import { PaymentRequestModel } from './components/ReceivePage/PaymentRequestList';
 
 const handleLocalStorageName = (networkName) => {
   if (networkName === BLOCKCHAIN_INFO_CHAIN_TEST) {
@@ -41,13 +40,6 @@ export const handleGetPaymentRequest = (networkName) => {
   return JSON.parse(
     PersistentStore.get(handleLocalStorageName(networkName)) || '[]'
   );
-};
-
-export const handleGetReceivedAddress = async (): Promise<
-  PaymentRequestModel[]
-> => {
-  const rpcClient = new RpcClient();
-  return await rpcClient.getListreceivedAddress();
 };
 
 export const handelAddReceiveTxns = (data, networkName) => {


### PR DESCRIPTION
There's an issue on _Add Liquidity Page -> Receive Shares At Dropdown_ where we have multiple addresses displayed. I used the addresses in _Wallet Page -> Receive_ as a data source.