### PR TITLE
feat: add AddressDropdown component and updated remove liquidity address

### DIFF
--- a/webapp/src/components/AddressDropdown/AddressDropdown.module.scss
+++ b/webapp/src/components/AddressDropdown/AddressDropdown.module.scss
@@ -1,0 +1,20 @@
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/mixins';
+@import '../../scss/variables';
+@import '../../scss/bootstrap/variables';
+@import '../../scss/utility';
+
+.divisibilityDropdown {
+  width: 100%;
+  text-align: left;
+  &:after {
+    float: right;
+    margin-top: 10px;
+  }
+}
+
+.scrollAuto {
+  overflow: auto;
+  height: 100px;
+}

--- a/webapp/src/components/AddressDropdown/index.tsx
+++ b/webapp/src/components/AddressDropdown/index.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { MdCheck } from 'react-icons/md';
+import { I18n } from 'react-redux-i18n';
+import {
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem,
+  Row,
+  Col,
+  UncontrolledDropdown,
+} from 'reactstrap';
+import { PaymentRequestModel } from '../../containers/WalletPage/components/ReceivePage/PaymentRequestList';
+import styles from './AddressDropdown.module.scss';
+import { AddressModel } from '../../model/address.model';
+
+export interface AddressDropdownProps {
+  formState: AddressModel;
+  paymentRequests: PaymentRequestModel[];
+  isDisabled?: boolean;
+  additionalClass?: () => string;
+  getTransactionLabel: (formState: any) => string;
+  onSelectAddress: (data: PaymentRequestModel, amount?: number) => void;
+}
+
+const AddressDropdown: React.FunctionComponent<AddressDropdownProps> = (
+  props: AddressDropdownProps
+) => {
+  const {
+    getTransactionLabel,
+    onSelectAddress,
+    formState,
+    paymentRequests,
+    additionalClass,
+    isDisabled,
+  } = props;
+  return (
+    <UncontrolledDropdown className='w-100'>
+      <DropdownToggle
+        caret
+        color='outline-secondary'
+        className={`${styles.divisibilityDropdown} ${
+          additionalClass ? additionalClass() : ''
+        }`}
+        disabled={isDisabled ?? false}
+      >
+        <div className={`${styles.ellipsisValue} ${styles.dropdownContent}`}>
+          {getTransactionLabel(formState)}
+        </div>
+      </DropdownToggle>
+      <DropdownMenu className={`${styles.scrollAuto} w-100`}>
+        <DropdownItem className='w-100'>
+          <Row className='w-100'>
+            <Col md='6'>{I18n.t('containers.swap.addLiquidity.address')}</Col>
+            <Col md='3'>{I18n.t('containers.swap.addLiquidity.label')}</Col>
+            <Col md='3'>{I18n.t('containers.swap.addLiquidity.selected')}</Col>
+          </Row>
+        </DropdownItem>
+        {paymentRequests.map((data) => {
+          return (
+            <DropdownItem
+              className='justify-content-between ml-0 w-100'
+              key={data.address}
+              name='receiveAddress'
+              onClick={() => onSelectAddress(data, data.amount)}
+              value={data.address}
+            >
+              <Row className='w-100'>
+                <Col md='6'>
+                  <div className={styles.ellipsisValue}>{data.address}</div>
+                </Col>
+                <Col md='3'>
+                  <div className={styles.ellipsisValue}>
+                    {data.label ? data.label : '---'}
+                  </div>
+                </Col>
+                <Col md='3'>
+                  {formState.receiveAddress === data.address && <MdCheck />}
+                </Col>
+              </Row>
+            </DropdownItem>
+          );
+        })}
+      </DropdownMenu>
+    </UncontrolledDropdown>
+  );
+};
+
+const mapStateToProps = (state) => {
+  const { paymentRequests } = state.wallet;
+  return {
+    paymentRequests,
+  };
+};
+
+export default connect(mapStateToProps)(AddressDropdown);

--- a/webapp/src/containers/LiquidityPage/components/AddLiquidity/index.tsx
+++ b/webapp/src/containers/LiquidityPage/components/AddLiquidity/index.tsx
@@ -3,22 +3,11 @@ import { Helmet } from 'react-helmet';
 import {
   MdAdd,
   MdArrowBack,
-  MdCheck,
   MdCheckCircle,
   MdErrorOutline,
 } from 'react-icons/md';
 import { I18n } from 'react-redux-i18n';
-import {
-  Button,
-  Col,
-  DropdownItem,
-  DropdownMenu,
-  DropdownToggle,
-  Modal,
-  ModalBody,
-  Row,
-  UncontrolledDropdown,
-} from 'reactstrap';
+import { Button, Col, Modal, ModalBody, Row } from 'reactstrap';
 import { NavLink as RRNavLink } from 'react-router-dom';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
@@ -32,6 +21,7 @@ import {
   fetchUtxoDfiRequest,
   fetchMaxAccountDfiRequest,
 } from '../../reducer';
+import AddressDropdown from '../../../../components/AddressDropdown';
 import styles from './addLiquidity.module.scss';
 import {
   BTC,
@@ -63,6 +53,7 @@ import openNewTab from '../../../../utils/openNewTab';
 import Header from '../../../HeaderComponent';
 import { handleFetchRegularDFI } from '../../../WalletPage/service';
 import { PaymentRequestModel } from '../../../WalletPage/components/ReceivePage/PaymentRequestList';
+import { AddressModel } from '../../../../model/address.model';
 
 interface AddLiquidityProps {
   location: any;
@@ -86,6 +77,9 @@ interface AddLiquidityProps {
   fetchMaxAccountDfiRequest: () => void;
   paymentRequests: PaymentRequestModel[];
 }
+export interface AddLiquidityFormState extends AddressModel {
+  [key: string]: any;
+}
 
 const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
   props: AddLiquidityProps
@@ -102,7 +96,7 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
   const [liquidityChangedMsg, setLiquidityChangedMsg] = useState<string>('');
   const [sufficientUtxos, setSufficientUtxos] = useState<boolean>(false);
 
-  const [formState, setFormState] = useState<any>({
+  const [formState, setFormState] = useState<AddLiquidityFormState>({
     amount1: '',
     hash1: '',
     symbol1: '',
@@ -171,8 +165,8 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
             hash1: idTokenA,
             symbol1: tokenA,
             balance1: balanceA,
-            receiveAddress: paymentRequests[0]?.address,
-            receiveLabel: paymentRequests[0]?.label,
+            receiveAddress: (paymentRequests ?? [])[0]?.address,
+            receiveLabel: (paymentRequests ?? [])[0]?.label,
           });
         } else if (!balanceA) {
           setFormState({
@@ -180,8 +174,8 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
             hash2: idTokenB,
             symbol2: tokenB,
             balance2: balanceB,
-            receiveAddress: paymentRequests[0]?.address,
-            receiveLabel: paymentRequests[0]?.label,
+            receiveAddress: (paymentRequests ?? [])[0]?.address,
+            receiveLabel: (paymentRequests ?? [])[0]?.label,
           });
         } else {
           setFormState({
@@ -192,8 +186,8 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
             symbol2: tokenB,
             balance1: balanceA,
             balance2: balanceB,
-            receiveAddress: paymentRequests[0]?.address,
-            receiveLabel: paymentRequests[0]?.label,
+            receiveAddress: (paymentRequests ?? [])[0]?.address,
+            receiveLabel: (paymentRequests ?? [])[0]?.label,
           });
         }
       } else {
@@ -205,8 +199,8 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
             hash1: DFI_SYMBOL,
             symbol1: DFI,
             balance1: balanceA,
-            receiveAddress: paymentRequests[0]?.address,
-            receiveLabel: paymentRequests[0]?.label,
+            receiveAddress: (paymentRequests ?? [])[0]?.address,
+            receiveLabel: (paymentRequests ?? [])[0]?.label,
           });
         } else {
           setFormState({
@@ -217,8 +211,8 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
             symbol2: BTC,
             balance1: balanceA,
             balance2: balanceB,
-            receiveAddress: paymentRequests[0]?.address,
-            receiveLabel: paymentRequests[0]?.label,
+            receiveAddress: (paymentRequests ?? [])[0]?.address,
+            receiveLabel: (paymentRequests ?? [])[0]?.label,
           });
         }
       }
@@ -568,63 +562,11 @@ const AddLiquidity: React.FunctionComponent<AddLiquidityProps> = (
               </span>
             </Col>
             <Col md='8'>
-              <UncontrolledDropdown className='w-100'>
-                <DropdownToggle
-                  caret
-                  color='outline-secondary'
-                  className={`${styles.divisibilityDropdown}`}
-                >
-                  <div
-                    className={`${styles.ellipsisValue} ${styles.dropdownContent}`}
-                  >
-                    {getTransactionLabel(formState)}
-                  </div>
-                </DropdownToggle>
-                <DropdownMenu className={`${styles.scrollAuto} w-100`}>
-                  <DropdownItem className='w-100'>
-                    <Row className='w-100'>
-                      <Col md='6'>
-                        {I18n.t('containers.swap.addLiquidity.address')}
-                      </Col>
-                      <Col md='3'>
-                        {I18n.t('containers.swap.addLiquidity.label')}
-                      </Col>
-                      <Col md='3'>
-                        {I18n.t('containers.swap.addLiquidity.selected')}
-                      </Col>
-                    </Row>
-                  </DropdownItem>
-                  {paymentRequests.map((data) => {
-                    return (
-                      <DropdownItem
-                        className='justify-content-between ml-0 w-100'
-                        key={data.address}
-                        name='receiveAddress'
-                        onClick={() => handleAddressDropdown(data)}
-                        value={data.address}
-                      >
-                        <Row className='w-100'>
-                          <Col md='6'>
-                            <div className={styles.ellipsisValue}>
-                              {data.address}
-                            </div>
-                          </Col>
-                          <Col md='3'>
-                            <div className={styles.ellipsisValue}>
-                              {data.label ? data.label : '---'}
-                            </div>
-                          </Col>
-                          <Col md='3'>
-                            {formState.receiveAddress === data.address && (
-                              <MdCheck />
-                            )}
-                          </Col>
-                        </Row>
-                      </DropdownItem>
-                    );
-                  })}
-                </DropdownMenu>
-              </UncontrolledDropdown>
+              <AddressDropdown
+                formState={formState}
+                getTransactionLabel={getTransactionLabel}
+                onSelectAddress={handleAddressDropdown}
+              />
             </Col>
           </Row>
           <br />

--- a/webapp/src/containers/LiquidityPage/components/RemoveLiquidity/index.tsx
+++ b/webapp/src/containers/LiquidityPage/components/RemoveLiquidity/index.tsx
@@ -1,18 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
-import {
-  MdArrowBack,
-  MdCheck,
-  MdCheckCircle,
-  MdErrorOutline,
-} from 'react-icons/md';
+import { MdArrowBack, MdCheckCircle, MdErrorOutline } from 'react-icons/md';
 import { I18n } from 'react-redux-i18n';
 import {
   Button,
   Col,
-  DropdownItem,
-  DropdownMenu,
-  DropdownToggle,
   FormGroup,
   Input,
   InputGroup,
@@ -20,7 +12,6 @@ import {
   InputGroupText,
   Label,
   Row,
-  UncontrolledDropdown,
   CustomInput,
 } from 'reactstrap';
 import {
@@ -30,24 +21,21 @@ import {
 } from 'react-router-dom';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import EllipsisText from 'react-ellipsis-text';
 
-import {
-  CONFIRM_BUTTON_COUNTER,
-  CONFIRM_BUTTON_TIMEOUT,
-  LIQUIDITY_PATH,
-} from '../../../../constants';
+import { LIQUIDITY_PATH } from '../../../../constants';
 import { fetchPoolpair, removePoolLiqudityRequest } from '../../reducer';
 import styles from './removeLiquidity.module.scss';
 import {
-  getIcon,
   getRatio,
   getTotalAmountPoolShare,
+  getTransactionAddressLabel,
 } from '../../../../utils/utility';
-import { getReceivingAddressAndAmountList } from '../../../TokensPage/service';
 import Spinner from '../../../../components/Svg/Spinner';
 import TokenAvatar from '../../../../components/TokenAvatar';
 import Header from '../../../HeaderComponent';
+import AddressDropdown from '../../../../components/AddressDropdown';
+import { AddressModel } from '../../../../model/address.model';
+import { PaymentRequestModel } from '../../../WalletPage/components/ReceivePage/PaymentRequestList';
 
 interface RouteParams {
   id?: string;
@@ -69,6 +57,11 @@ interface RemoveLiquidityProps extends RouteComponentProps<RouteParams> {
   liquidityRemovedLoaded: boolean;
   refreshUTXOS2Loaded: boolean;
   transferTokensLoaded: boolean;
+  paymentRequests: PaymentRequestModel[];
+}
+
+export interface RemoveLiquidityFormState extends AddressModel {
+  [key: string]: any;
 }
 
 const RemoveLiquidity: React.FunctionComponent<RemoveLiquidityProps> = (
@@ -80,12 +73,12 @@ const RemoveLiquidity: React.FunctionComponent<RemoveLiquidityProps> = (
   const [removeLiquidityStep, setRemoveLiquidityStep] = useState<string>(
     'default'
   );
-  const [receiveAddresses, setReceiveAddresses] = useState<any>([]);
   const [allowCalls, setAllowCalls] = useState<boolean>(false);
   const [sumAmount, setSumAmount] = useState<number>(0);
-  const [formState, setFormState] = useState<any>({
+  const [formState, setFormState] = useState<RemoveLiquidityFormState>({
     amountPercentage: '0',
     receiveAddress: '',
+    receiveLabel: '',
   });
 
   const { id } = props.match.params;
@@ -105,6 +98,7 @@ const RemoveLiquidity: React.FunctionComponent<RemoveLiquidityProps> = (
     liquidityRemovedLoaded,
     refreshUTXOS2Loaded,
     history,
+    paymentRequests,
   } = props;
 
   useEffect(() => {
@@ -131,11 +125,10 @@ const RemoveLiquidity: React.FunctionComponent<RemoveLiquidityProps> = (
 
   useEffect(() => {
     async function addressAndAmount() {
-      const data = await getReceivingAddressAndAmountList();
-      setReceiveAddresses(data.addressAndAmountList);
       setFormState({
         ...formState,
-        receiveAddress: data.addressAndAmountList[0]?.address,
+        receiveAddress: (paymentRequests ?? [])[0]?.address,
+        receiveLabel: (paymentRequests ?? [])[0]?.label,
       });
     }
     addressAndAmount();
@@ -171,6 +164,22 @@ const RemoveLiquidity: React.FunctionComponent<RemoveLiquidityProps> = (
 
   const totalA = calculateTotal(sharePercentage, poolpair.reserveA);
   const totalB = calculateTotal(sharePercentage, poolpair.reserveB);
+
+  const getTransactionLabel = (formState: any) => {
+    return getTransactionAddressLabel(
+      formState.receiveLabel,
+      formState.receiveAddress,
+      I18n.t('containers.swap.removeLiquidity.receiveAddressDropdown')
+    );
+  };
+
+  const handleAddressDropdown = (data: any) => {
+    setFormState({
+      ...formState,
+      receiveAddress: data.address,
+      receiveLabel: data.label,
+    });
+  };
 
   return (
     <div className='main-wrapper'>
@@ -316,47 +325,11 @@ const RemoveLiquidity: React.FunctionComponent<RemoveLiquidityProps> = (
               {I18n.t('containers.swap.removeLiquidity.receiveAddressLabel')}
             </Col>
             <Col md='8'>
-              <UncontrolledDropdown>
-                <DropdownToggle
-                  caret
-                  color='outline-secondary'
-                  className={`${styles.receiveAddressDropdown}`}
-                  // disabled={isUpdate}
-                >
-                  {formState.receiveAddress
-                    ? formState.receiveAddress
-                    : I18n.t(
-                        'containers.swap.removeLiquidity.receiveAddressDropdown'
-                      )}
-                </DropdownToggle>
-                <DropdownMenu className={`${styles.receiveAddressMenu}`}>
-                  {receiveAddresses.map((data) => {
-                    return (
-                      <DropdownItem
-                        key={data.address}
-                        name='receiveAddress'
-                        onClick={() =>
-                          setFormState({
-                            ...formState,
-                            receiveAddress: data.address,
-                          })
-                        }
-                        value={data.address}
-                      >
-                        <EllipsisText text={data.address} length={'42'} />
-                        <EllipsisText
-                          className={styles.receiveAddressMenuLabel}
-                          text={data.label ? `${data.label}` : ''}
-                          length={'20'}
-                        />
-                        {formState.receiveAddress === data.address && (
-                          <MdCheck className={styles.receiveAddressMenuCheck} />
-                        )}
-                      </DropdownItem>
-                    );
-                  })}
-                </DropdownMenu>
-              </UncontrolledDropdown>
+              <AddressDropdown
+                formState={formState}
+                getTransactionLabel={getTransactionLabel}
+                onSelectAddress={handleAddressDropdown}
+              />
             </Col>
           </FormGroup>
         </section>
@@ -641,6 +614,7 @@ const mapStateToProps = (state) => {
     refreshUTXOS2Loaded,
     transferTokensLoaded,
   } = state.swap;
+  const { paymentRequests } = state.wallet;
   return {
     removePoolLiquidityHash,
     isLoadingRemovePoolLiquidity,
@@ -654,6 +628,7 @@ const mapStateToProps = (state) => {
     liquidityRemovedLoaded,
     refreshUTXOS2Loaded,
     transferTokensLoaded,
+    paymentRequests,
   };
 };
 

--- a/webapp/src/containers/TokensPage/components/CreateToken/CreateDCT/Footer/index.tsx
+++ b/webapp/src/containers/TokensPage/components/CreateToken/CreateDCT/Footer/index.tsx
@@ -12,10 +12,11 @@ import {
 } from '../../../../../../constants';
 import { ITokenResponse } from '../../../../../../utils/interfaces';
 import Spinner from '../../../../../../components/Svg/Spinner';
+import { CreateTokenFormState } from '../..';
 
 interface CreateDCTProps {
   isUpdate: boolean;
-  formState: any;
+  formState: CreateTokenFormState;
   isConfirmationModalOpen: string;
   setIsConfirmationModalOpen: (state: string) => void;
   cancelConfirmation: () => void;
@@ -94,7 +95,7 @@ const Footer: React.FunctionComponent<CreateDCTProps> = (
                 <Button
                   disabled={
                     !formState.symbol ||
-                    !formState.collateralAddress ||
+                    !formState.receiveAddress ||
                     formState.symbol.length > 8 ||
                     formState.name.length > 128 ||
                     !IsCollateralAddressValid

--- a/webapp/src/containers/TokensPage/components/CreateToken/CreateDCT/index.tsx
+++ b/webapp/src/containers/TokensPage/components/CreateToken/CreateDCT/index.tsx
@@ -18,7 +18,6 @@ import {
   Row,
   Col,
 } from 'reactstrap';
-import EllipsisText from 'react-ellipsis-text';
 
 import Footer from './Footer';
 import styles from './CreateDCT.module.scss';
@@ -26,11 +25,12 @@ import { TOKENS_PATH } from '../../../../../constants';
 import { ITokenResponse } from '../../../../../utils/interfaces';
 import Header from '../../../../HeaderComponent';
 import { getTransactionAddressLabel } from '../../../../../utils/utility';
+import AddressDropdown from '../../../../../components/AddressDropdown';
+import { CreateTokenFormState } from '..';
 
 interface CreateDCTProps {
   handleChange: (e) => void;
-  formState: any;
-  collateralAddresses: any;
+  formState: CreateTokenFormState;
   IsCollateralAddressValid: boolean;
   isConfirmationModalOpen: string;
   setIsConfirmationModalOpen: (state: string) => void;
@@ -47,8 +47,12 @@ interface CreateDCTProps {
   isUpdate: boolean;
 }
 
-const getTransactionLabel = (formState: any) => {
-  return getTransactionAddressLabel(formState.collateralLabel, formState.collateralAddress, I18n.t('containers.tokens.createToken.collateralAddress'));
+const getTransactionLabel = (formState: CreateTokenFormState) => {
+  return getTransactionAddressLabel(
+    formState.receiveLabel,
+    formState.receiveAddress,
+    I18n.t('containers.tokens.createToken.collateralAddress')
+  );
 };
 
 const CreateDCT: React.FunctionComponent<CreateDCTProps> = (
@@ -58,7 +62,6 @@ const CreateDCT: React.FunctionComponent<CreateDCTProps> = (
     isUpdate,
     handleChange,
     formState,
-    collateralAddresses,
     IsCollateralAddressValid,
     handleDropDowns,
     isConfirmationModalOpen,
@@ -244,73 +247,15 @@ const CreateDCT: React.FunctionComponent<CreateDCTProps> = (
                 </Row>
               </Col>
             </Row> */}
-            <UncontrolledDropdown className='w-100'>
-              <DropdownToggle
-                caret
-                color='outline-secondary'
-                className={`${styles.divisibilityDropdown}
-                ${!IsCollateralAddressValid ? styles.collateralDropdown : ''}`}
-                disabled={isUpdate}
-              >
-                <div
-                    className={`${styles.ellipsisValue} ${styles.dropdownContent}`}
-                  >
-                    {getTransactionLabel(formState)}
-                  </div>
-              </DropdownToggle>
-              <DropdownMenu className={`${styles.scrollAuto} w-100`}>
-                <DropdownItem className='w-100'>
-                  <Row className='w-100'>
-                    <Col md='6'>
-                      {I18n.t('containers.tokens.createToken.address')}
-                    </Col>
-                    <Col md='3'>
-                      {I18n.t('containers.tokens.createToken.label')}
-                    </Col>
-                    <Col md='3'>
-                      {I18n.t('containers.tokens.createToken.selected')}
-                    </Col>
-                  </Row>
-                </DropdownItem>
-                {collateralAddresses.map((data) => {
-                  return (
-                    <DropdownItem
-                      className='justify-content-between ml-0 w-100'
-                      key={data.address}
-                      name='collateralAddress'
-                      onClick={() =>
-                        handleDropDowns(
-                          {
-                            collateralAddress: data.address,
-                            collateralLabel: data.label
-                          },
-                          data.amount
-                        )
-                      }
-                      value={data.address}
-                    >
-                      <Row className='w-100'>
-                        <Col md='6'>
-                            <div className={styles.ellipsisValue}>
-                              {data.address}
-                            </div>
-                        </Col>
-                        <Col md='3'>
-                            <div className={styles.ellipsisValue}>
-                              {data.label ? data.label : '---'}
-                            </div>
-                        </Col>
-                        <Col md='3'>
-                          {formState.collateralAddress === data.address && (
-                            <MdCheck />
-                          )}
-                        </Col>
-                      </Row>
-                    </DropdownItem>
-                  );
-                })}
-              </DropdownMenu>
-            </UncontrolledDropdown>
+            <AddressDropdown
+              formState={formState}
+              getTransactionLabel={getTransactionLabel}
+              onSelectAddress={handleDropDowns}
+              additionalClass={() =>
+                !IsCollateralAddressValid ? styles.collateralDropdown : ''
+              }
+              isDisabled={isUpdate}
+            />
             {!IsCollateralAddressValid && (
               <FormText className={`${styles.collateralFormText} mt-2`}>
                 {I18n.t('containers.tokens.createToken.collateralAddressError')}

--- a/webapp/src/containers/TokensPage/components/CreateToken/index.tsx
+++ b/webapp/src/containers/TokensPage/components/CreateToken/index.tsx
@@ -7,7 +7,6 @@ import isEmpty from 'lodash/isEmpty';
 import DCTDistribution from './DCTDistribution';
 import CreateDCT from './CreateDCT';
 import { createToken, fetchTokenInfo, updateToken } from '../../reducer';
-import { getReceivingAddressAndAmountList } from '../../service';
 import {
   CONFIRM_BUTTON_COUNTER,
   CONFIRM_BUTTON_TIMEOUT,
@@ -17,6 +16,7 @@ import {
 } from '../../../../constants';
 import { ITokenResponse } from '../../../../utils/interfaces';
 import { PaymentRequestModel } from '../../../WalletPage/components/ReceivePage/PaymentRequestList';
+import { AddressModel } from '../../../../model/address.model';
 
 interface RouteParams {
   id?: string;
@@ -36,6 +36,10 @@ interface CreateTokenProps extends RouteComponentProps<RouteParams> {
   paymentRequests: PaymentRequestModel[];
 }
 
+export interface CreateTokenFormState extends AddressModel {
+  [key: string]: any;
+}
+
 const CreateToken: React.FunctionComponent<CreateTokenProps> = (
   props: CreateTokenProps
 ) => {
@@ -44,7 +48,7 @@ const CreateToken: React.FunctionComponent<CreateTokenProps> = (
   const [IsCollateralAddressValid, setIsCollateralAddressValid] = useState<
     boolean
   >(true);
-  const [formState, setFormState] = useState<any>({
+  const [formState, setFormState] = useState<CreateTokenFormState>({
     name: '',
     symbol: '',
     isDAT: false,
@@ -52,8 +56,8 @@ const CreateToken: React.FunctionComponent<CreateTokenProps> = (
     limit: '0',
     mintable: 'true',
     tradeable: 'true',
-    collateralAddress: '',
-    collateralLabel: '',
+    receiveAddress: '',
+    receiveLabel: '',
   });
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState<
     string
@@ -72,21 +76,6 @@ const CreateToken: React.FunctionComponent<CreateTokenProps> = (
     fetchToken(id);
   }, []);
 
-  useEffect(() => {
-    if (!isEmpty(tokenInfo) && id) {
-      const data = {
-        name: tokenInfo.name,
-        symbol: tokenInfo.symbol,
-        isDAT: tokenInfo.isDAT,
-        decimal: tokenInfo.decimal.toString(),
-        limit: tokenInfo.limit.toString(),
-        mintable: tokenInfo.mintable.toString(),
-        tradeable: tokenInfo.tradeable.toString(),
-      };
-      setFormState(data);
-    }
-  }, [tokenInfo]);
-
   const {
     createToken,
     updateToken,
@@ -100,11 +89,28 @@ const CreateToken: React.FunctionComponent<CreateTokenProps> = (
   } = props;
 
   useEffect(() => {
+    if (!isEmpty(tokenInfo) && id) {
+      const data: CreateTokenFormState = {
+        name: tokenInfo.name,
+        symbol: tokenInfo.symbol,
+        isDAT: tokenInfo.isDAT,
+        decimal: tokenInfo.decimal.toString(),
+        limit: tokenInfo.limit.toString(),
+        mintable: tokenInfo.mintable.toString(),
+        tradeable: tokenInfo.tradeable.toString(),
+        receiveAddress: (paymentRequests ?? [])[0]?.address,
+        receiveLabel: (paymentRequests ?? [])[0]?.label,
+      };
+      setFormState(data);
+    }
+  }, [tokenInfo]);
+
+  useEffect(() => {
     async function addressAndAmount() {
       setFormState({
         ...formState,
-        collateralAddress: paymentRequests[0]?.address,
-        collateralLabel: paymentRequests[0]?.label,
+        receiveAddress: (paymentRequests ?? [])[0]?.address,
+        receiveLabel: (paymentRequests ?? [])[0]?.label,
       });
     }
     addressAndAmount();
@@ -203,7 +209,6 @@ const CreateToken: React.FunctionComponent<CreateTokenProps> = (
             isUpdate={!isEmpty(tokenInfo) && !!id}
             handleChange={handleChange}
             formState={formState}
-            collateralAddresses={paymentRequests}
             isErrorCreatingToken={isErrorCreatingToken}
             createdTokenData={createdTokenData}
             updatedTokenData={updatedTokenData}

--- a/webapp/src/containers/TokensPage/components/CreateToken/index.tsx
+++ b/webapp/src/containers/TokensPage/components/CreateToken/index.tsx
@@ -178,6 +178,10 @@ const CreateToken: React.FunctionComponent<CreateTokenProps> = (
     setActiveTab(active);
   };
 
+  const createTokenData = () => {
+    return { ...formState, collateralAddress: formState.receiveAddress };
+  };
+
   const cancelConfirmation = () => {
     setWait(5);
     setIsConfirmationModalOpen('default');
@@ -185,19 +189,19 @@ const CreateToken: React.FunctionComponent<CreateTokenProps> = (
 
   const createConfirmation = () => {
     setAllowCalls(true);
-    const tokenData = { ...formState };
+    const tokenData = createTokenData();
     setIsConfirmationModalOpen('loading');
     createToken(tokenData);
   };
 
   const updateConfirmation = () => {
     setAllowCalls(true);
-    const tokenData = { ...formState };
+    const tokenData = createTokenData();
     updateToken(tokenData);
   };
 
   const handleSubmit = async () => {
-    const tokenData = { ...formState };
+    const tokenData = createTokenData();
     createToken(tokenData);
   };
 

--- a/webapp/src/containers/TokensPage/service.tsx
+++ b/webapp/src/containers/TokensPage/service.tsx
@@ -82,7 +82,7 @@ export const handleCreateTokens = async (tokenData) => {
     limit: Number(tokenData.limit),
     mintable: JSON.parse(tokenData.mintable),
     tradeable: JSON.parse(tokenData.tradeable),
-    collateralAddress: tokenData.collateralAddress,
+    collateralAddress: tokenData.collateralAddress ?? tokenData.receiveAddress,
   };
   if (!tokenData.name) {
     delete data.name;

--- a/webapp/src/model/address.model.ts
+++ b/webapp/src/model/address.model.ts
@@ -1,0 +1,4 @@
+export interface AddressModel {
+  receiveAddress: string;
+  receiveLabel: string;
+}


### PR DESCRIPTION
Receive address dropdown is used on multiple pages, _(e.g, Create Token, Add Liquidity, Remove Liquidity)_. I have created a new component _AddressDropdown_ that will be used for all these pages and future pages so logic and style will be same.