### PR TITLE
fix: disable menu wallet commands if there is no wallet available

### DIFF
--- a/electron-app/src/app.ts
+++ b/electron-app/src/app.ts
@@ -70,9 +70,12 @@ export default class App {
     autoUpdater.checkForUpdatesAndNotify().catch((e) => {
       log.error(e);
     });
-    
+
     initiateElectronUpdateManager(autoUpdater, this.mainWindow);
-    initiateBackupImportWalletManager(this.mainWindow, this.createMenu.bind(this));
+    initiateBackupImportWalletManager(
+      this.mainWindow,
+      this.createMenu.bind(this)
+    );
     createMnemonicAction();
   };
 
@@ -128,9 +131,9 @@ export default class App {
   }
 
   // Create menu
-  createMenu(enableReset?: boolean) {
+  createMenu(isWalletLoaded?: boolean) {
     const appMenu = new AppMenu();
-    const template = appMenu.getTemplate(enableReset);
+    const template = appMenu.getTemplate(isWalletLoaded);
     const menu = Menu.buildFromTemplate(template);
     Menu.setApplicationMenu(menu);
   }

--- a/electron-app/src/ipc-events/backupAndImportWallet.ts
+++ b/electron-app/src/ipc-events/backupAndImportWallet.ts
@@ -41,13 +41,16 @@ const initiateBackupImportWalletManager = (
     }
   });
 
-  ipcMain.on(ENABLE_RESET_MENU, async () => {
-    try {
-      createMenu(true);
-    } catch (err) {
-      console.log(err);
+  ipcMain.on(
+    ENABLE_RESET_MENU,
+    async (event: Electron.IpcMainEvent, arg: any) => {
+      try {
+        createMenu(arg?.isWalletCreatedFlag);
+      } catch (err) {
+        console.log(err);
+      }
     }
-  });
+  );
 };
 
 export default initiateBackupImportWalletManager;

--- a/electron-app/src/menus/index.ts
+++ b/electron-app/src/menus/index.ts
@@ -12,13 +12,14 @@ import { logFilePath } from '../services/electronLogger';
 import Logs from '../controllers/logs';
 
 export default class AppMenu {
-  getTemplate(enableReset?: boolean) {
+  getTemplate(isWalletLoaded?: boolean) {
     const template: Electron.MenuItemConstructorOptions[] = [
       {
         label: 'Wallet',
         submenu: [
           {
             label: 'Import Wallet',
+            enabled: !!isWalletLoaded,
             click(item, bw) {
               const wallet = new Wallet();
               wallet.load(bw);
@@ -26,6 +27,7 @@ export default class AppMenu {
           },
           {
             label: 'Backup Wallet',
+            enabled: !!isWalletLoaded,
             click(item, bw) {
               const wallet = new Wallet();
               wallet.startBackupWallet(bw);
@@ -33,7 +35,7 @@ export default class AppMenu {
           },
           {
             label: 'Reset Wallet',
-            enabled: !!enableReset,
+            enabled: !!isWalletLoaded,
             click(item, bw) {
               const wallet = new Wallet();
               wallet.resetWallet(bw);

--- a/webapp/src/app/update.ipcRenderer.ts
+++ b/webapp/src/app/update.ipcRenderer.ts
@@ -71,10 +71,10 @@ export const createMnemonicIpcRenderer = async (mnemonic, network) => {
   }
 };
 
-export const enableMenuResetWalletBtn = () => {
+export const enableMenuResetWalletBtn = (isWalletCreatedFlag: boolean) => {
   if (isElectron()) {
     const ipcRenderer = ipcRendererFunc();
-    ipcRenderer.send('enable-reset');
+    ipcRenderer.send('enable-reset', { isWalletCreatedFlag });
   }
 };
 export default initUpdateAppIpcRenderers;

--- a/webapp/src/containers/RpcConfiguration/saga.ts
+++ b/webapp/src/containers/RpcConfiguration/saga.ts
@@ -22,12 +22,8 @@ import {
   closeRestartLoader,
   setIsQueueResetRoute,
 } from '../PopOver/reducer';
-import {
-  fetchPaymentRequest,
-  setIsWalletCreatedRequest,
-} from '../WalletPage/reducer';
+import { fetchPaymentRequest } from '../WalletPage/reducer';
 import { fetchChainInfo } from '../WalletPage/saga';
-import { isWalletCreated } from '../../utils/utility';
 import { enableMenuResetWalletBtn } from '../../app/update.ipcRenderer';
 import { history } from '../../utils/history';
 import { WALLET_TOKENS_PATH } from '../../constants';
@@ -87,7 +83,8 @@ export function* getConfig() {
 export function* preCheck() {
   yield call(fetchChainInfo);
   yield put(fetchPaymentRequest());
-  yield call(enableMenuResetWalletBtn);
+  const { isWalletCreatedFlag } = yield select((state) => state.wallet);
+  yield call(enableMenuResetWalletBtn, isWalletCreatedFlag);
 }
 
 function* mySaga() {

--- a/webapp/src/containers/WalletPage/saga.tsx
+++ b/webapp/src/containers/WalletPage/saga.tsx
@@ -96,7 +96,10 @@ import {
   WALLET_TOKENS_PATH,
 } from '../../constants';
 import PersistentStore from '../../utils/persistentStore';
-import { createMnemonicIpcRenderer } from '../../app/update.ipcRenderer';
+import {
+  createMnemonicIpcRenderer,
+  enableMenuResetWalletBtn,
+} from '../../app/update.ipcRenderer';
 import minBy from 'lodash/minBy';
 import orderBy from 'lodash/orderBy';
 import uid from 'uid';
@@ -388,6 +391,7 @@ export function* restoreWallet(action) {
     yield put({ type: restoreWalletSuccess.type });
     PersistentStore.set(isWalletCreated, true);
     yield put(setIsWalletCreatedRequest(true));
+    yield call(enableMenuResetWalletBtn, true);
     history.push(WALLET_TOKENS_PATH);
   } catch (e) {
     log.error(e.message);


### PR DESCRIPTION
If wallet is not existing, disable the Import, Reset and Backup Wallet.