### PR TITLE
Update pre-build-linux.sh

### DIFF
--- a/pre-build-linux.sh
+++ b/pre-build-linux.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+#!/usr/bin/env fish
 mkdir -p binary
 cd binary && rm -rf win mac linux
 mkdir linux


### PR DESCRIPTION
without headers cannot be launched in fish shell