### PR TITLE
fix: re-index on any node syntax errors

### DIFF
--- a/electron-app/src/constants/app.ts
+++ b/electron-app/src/constants/app.ts
@@ -34,3 +34,4 @@ export const STOP_BINARY_INTERVAL = 500;
 export const REINDEX_ERROR_STRING = 'restart with -reindex';
 export const ACCOUNT_HISTORY_REINDEX_ERROR_STRING =
   'Account history needs rebuild';
+export const NODE_SYNTAX_ERROR = '.cpp';

--- a/electron-app/src/services/defiprocessmanager.ts
+++ b/electron-app/src/services/defiprocessmanager.ts
@@ -14,6 +14,7 @@ import {
   STOP_BINARY_INTERVAL,
   REINDEX_ERROR_STRING,
   ACCOUNT_HISTORY_REINDEX_ERROR_STRING,
+  NODE_SYNTAX_ERROR,
 } from '../constants';
 import {
   checkPathExists,
@@ -100,13 +101,17 @@ export default class DefiProcessManager {
       child.stderr.on('data', (err) => {
         const regex = new RegExp(REINDEX_ERROR_STRING, 'gi');
         const regex1 = new RegExp(ACCOUNT_HISTORY_REINDEX_ERROR_STRING, 'gi');
+        // any syntax errors from node side, force a reindex to avoid stoppage of app.
+        const nodeRegexSyntax = new RegExp(NODE_SYNTAX_ERROR, 'gi');
+        const regexCheck = [regex, regex1, nodeRegexSyntax];
 
         const errorString = err?.toString('utf8').trim();
-        const res = regex.test(errorString) || regex1.test(errorString);
-
+        const shouldReindex = regexCheck.some((reg: RegExp) =>
+          reg.test(errorString)
+        );
         // change value of isReindexReq variable based on regex evaluation
-        if (res) {
-          this.isReindexReq = res;
+        if (shouldReindex) {
+          this.isReindexReq = shouldReindex;
         }
 
         if (event)


### PR DESCRIPTION
Currently, we have some node syntax errors that breaks the app. Even if you restart, it still returns the same error. I have added a test that if the error is from node side, we will consider it for re-index.