### PR TITLE
chore: bump node version to 1.4.2 and added param

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/DeFiCh/app",
   "publicPath": "./",
-  "ainVersion": "1.4.1",
+  "ainVersion": "1.4.2",
   "scripts": {
     "init": "npm ci && cd webapp && npm run init",
     "transpile": "tsc --p tsconfig.json && tspr --tsConfig tsconfig.json",

--- a/webapp/src/utils/rpc-client.ts
+++ b/webapp/src/utils/rpc-client.ts
@@ -372,6 +372,7 @@ export default class RpcClient {
       {},
       {
         [toAddress]: amount,
+        enable_external_dfi_token_tx: true,
       },
     ]);
     return data.result;

--- a/webapp/src/utils/rpc-client.ts
+++ b/webapp/src/utils/rpc-client.ts
@@ -357,6 +357,7 @@ export default class RpcClient {
       fromAddress,
       {
         [toAddress]: amount,
+        enable_external_dfi_token_tx: true,
       },
       [],
     ]);


### PR DESCRIPTION
1. Bumped Node to 1.4.2
2. Added parameter `enable_external_dfi_token_tx` to accounttoaccount and sendtokenstoaddress calls