### PR TITLE
Fix: i18n output for searchBar placeholder

### DIFF
--- a/webapp/src/components/SearchBar/index.tsx
+++ b/webapp/src/components/SearchBar/index.tsx
@@ -10,7 +10,6 @@ import {
 } from 'reactstrap';
 import classnames from 'classnames';
 import styles from './SearchBar.module.scss';
-import { I18n } from 'react-redux-i18n';
 
 interface SearchBarProps {
   searching: any;

--- a/webapp/src/containers/MasternodesPage/index.tsx
+++ b/webapp/src/containers/MasternodesPage/index.tsx
@@ -222,7 +222,9 @@ const MasternodesPage: React.FunctionComponent<MasternodesPageProps> = (
           onChange={(e) => setSearchQuery(e.target.value)}
           searching={searching}
           toggleSearch={toggleSearch}
-          placeholder={'Search masternodes'}
+          placeholder={I18n.t(
+            'containers.masterNodes.masterNodesPage.searchBar'
+          )}
         />
       </Header>
       <div className='content'>


### PR DESCRIPTION
- Current result: `searchBar` placeholder is not translated
- Expected result: `searchBar` placeholder is a translated string