### PR TITLE
Fix: Make „Enter word“ placeholder translatable

### DIFF
--- a/webapp/src/containers/WalletPage/components/RestoreWallet/index.tsx
+++ b/webapp/src/containers/WalletPage/components/RestoreWallet/index.tsx
@@ -129,7 +129,9 @@ const RestoreWallet: React.FunctionComponent<RestoreWalletProps> = (
                     </InputGroupText>
                   </InputGroupAddon>
                   <Input
-                    placeholder='Enter word'
+                    placeholder={I18n.t(
+                      'containers.wallet.restoreWalletPage.enterWord'
+                    )}
                     value={mnemonicObj[key]}
                     onChange={(event) => onchangeHandle(event, key)}
                     className='border-left-0'

--- a/webapp/src/translations/languages/de.json
+++ b/webapp/src/translations/languages/de.json
@@ -599,6 +599,7 @@
         "title": "Wallet - Wallet wiederherstellen",
         "restoreWallet": "Wallet wiederherstellen",
         "restoreWalletGuideLine": "Gebe die 24 Wörter in deinem Mnemonic Seed ein, um die Wallet wiederherzustellen.",
+        "enterWord": "Wort eingeben",
         "restoringWallet": "Wallet wird wiederhergestellt",
         "restore": "WIEDERHERSTELLEN",
         "backToWalletPage": "SCHLIESSEN"

--- a/webapp/src/translations/languages/en.json
+++ b/webapp/src/translations/languages/en.json
@@ -595,6 +595,7 @@
         "title": "Wallet - Restore wallet",
         "restoreWallet": "Restore wallet",
         "restoreWalletGuideLine": "Enter the 24 words in your mnemonic seed to restore wallet.",
+        "enterWord": "Enter word",
         "restoringWallet": "Restoring wallet",
         "restore": "Restore",
         "backToWalletPage": "Close"


### PR DESCRIPTION
- Current result: `Enter word` placeholder at restore wallet page is not translated
- Expected result: `Enter word` placeholder at restore wallet page is a translated string