### PR TITLE
Fix: Decimal string at tokens page

### DIFF
--- a/webapp/src/components/TokenCard/DCT/index.tsx
+++ b/webapp/src/components/TokenCard/DCT/index.tsx
@@ -63,8 +63,8 @@ const TokenCard: React.FunctionComponent<ITokenCard> = (props: ITokenCard) => {
         </Row>
         <Row>
           <Col className={styles.label}>
-            {/* {I18n.t('conainers.tokens.tokensPage.dctLabels.finalSupplyLimit')} */}
-            {I18n.t('conainers.tokens.tokensPage.dctLabels.decimal')}
+            {/* {I18n.t('containers.tokens.tokensPage.dctLabels.finalSupplyLimit')} */}
+            {I18n.t('containers.tokens.tokensPage.dctLabels.decimal')}
           </Col>
           <Col className={`${styles.unit} ${styles.text}`}>
             {/* {data.finalSupplyLimit} */}


### PR DESCRIPTION
Current result: `Decimal` string has a wrong translation key.
Expected result: `Decimal` string has a correct translation key.

<img width="1339" alt="Bildschirmfoto 2021-01-23 um 19 09 17" src="https://user-images.githubusercontent.com/108992/105610272-2cf75a00-5daf-11eb-9b88-f3d0f1f31d12.png">
