### PR TITLE
Fix: New wallet footer buttons alignment

### DIFF
--- a/webapp/src/containers/WalletPage/components/CreateWallet/CreateNewWallet/index.tsx
+++ b/webapp/src/containers/WalletPage/components/CreateWallet/CreateNewWallet/index.tsx
@@ -149,7 +149,6 @@ const CreateNewWallet: React.FunctionComponent<CreateNewWalletProps> = (
             <Col className='d-flex justify-content-end'>
               <Button
                 color='primary'
-                className='mr-3'
                 disabled={!isChecked}
                 onClick={() => {
                   setIsWalletTabActive(!isWalletTabActive);

--- a/webapp/src/containers/WalletPage/components/CreateWallet/VerifyMnemonic/index.tsx
+++ b/webapp/src/containers/WalletPage/components/CreateWallet/VerifyMnemonic/index.tsx
@@ -251,6 +251,7 @@ const VerifyMnemonic: React.FunctionComponent<VerifyMnemonicProps> = (
                   <Button
                     color='link'
                     size='sm'
+                    className='footer-bar-back'
                     onClick={() => {
                       setIsWalletTabActive(!isWalletTabActive);
                     }}

--- a/webapp/src/scss/_layout.scss
+++ b/webapp/src/scss/_layout.scss
@@ -131,6 +131,11 @@ body {
       border-top: $border-width solid $border-color;
       border-bottom-left-radius: $border-radius * 1.5;
       width: 100%;
+
+      &-back {
+        padding-left: 0;
+        padding-right: 0;
+      }
     }
 
     .footer-sheet {


### PR DESCRIPTION
* Align right the `Continue` button
* Align left the `Show me my 24 words again` button

<img width="1032" alt="Bildschirmfoto 2021-01-31 um 19 10 20" src="https://user-images.githubusercontent.com/108992/106393653-b387e900-63f8-11eb-8b79-d19196136cdd.png">

<img width="1033" alt="Bildschirmfoto 2021-01-31 um 19 10 31" src="https://user-images.githubusercontent.com/108992/106393661-b97dca00-63f8-11eb-9627-6daadc4ce480.png">
