### PR TITLE
Pin github-actions to a full length commit SHA

### DIFF
--- a/.github/workflows/dev-builds.yml
+++ b/.github/workflows/dev-builds.yml
@@ -6,20 +6,25 @@ on:
   pull_request:
     branches:
       - master
+
 jobs:
   build_linux_version:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
       - name: Get App Version
-        uses: nyaayaya/package-version@v1
+        uses: nyaayaya/package-version@05847b5b2b4e8cefeca8d50ee5940a6445a5773a
+
       - name: install dependencies
         run: npm cache clean --force && npm run init
+
       - name: Build app
         run: npm run build:linux
-      - uses: actions/upload-artifact@v2
+
+      - uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
         with:
           name: linux-build
           path: 'dist/defi-app-${{ env.PACKAGE_VERSION}}.AppImage'
@@ -34,14 +39,18 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID}}
       APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
       - name: Get App Version
-        uses: nyaayaya/package-version@v1
+        uses: nyaayaya/package-version@05847b5b2b4e8cefeca8d50ee5940a6445a5773a
+
       - name: install dependencies
         run: npm cache clean --force && npm run init
+
       - name: Build app
         run: npm run build:mac
-      - uses: actions/upload-artifact@v2
+
+      - uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
         with:
           name: mac-build
           path: 'dist/defi-app-${{ env.PACKAGE_VERSION}}.dmg'
@@ -51,15 +60,19 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
       - name: Get App Version
-        uses: nyaayaya/package-version@v1
+        uses: nyaayaya/package-version@05847b5b2b4e8cefeca8d50ee5940a6445a5773a
+
       - name: install dependencies
         run: npm cache clean --force && npm run init
+
       - name: Build app
         run: npm run build:win
         shell: powershell
-      - uses: actions/upload-artifact@v2
+
+      - uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
         with:
           name: win-build
           path: 'dist/defi-app Setup ${{ env.PACKAGE_VERSION}}.exe'

--- a/.github/workflows/release-builds.yml
+++ b/.github/workflows/release-builds.yml
@@ -9,7 +9,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: install dependencies
         run: npm cache clean --force && npm run init
@@ -27,27 +27,32 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
       - name: Get App Version
-        uses: nyaayaya/package-version@v1
+        uses: nyaayaya/package-version@05847b5b2b4e8cefeca8d50ee5940a6445a5773a
+
       - name: Fetch Release Asset
-        uses: Legion2/download-release-action@v2.1.0
+        uses: Legion2/download-release-action@68df3d242858e28a7e6d8b9838a3e6730cdfc422
         with:
           repository: 'DeFiCh/app'
           tag: 'v${{ env.PACKAGE_VERSION}}'
           file: 'defi-app-${{ env.PACKAGE_VERSION}}.AppImage'
+
       - name: Get Release Info with Tag Name
         id: latest_release_info
-        uses: leahlundqvist/get-release@v1.3.1
+        uses: leahlundqvist/get-release@89e1ed4ad1c1951f278c6415dd6002bf0a992faf
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: 'v${{ env.PACKAGE_VERSION}}'
+
       - name: Generate SHA256 checksum
         run: |
           sha256sum defi-app-${{ env.PACKAGE_VERSION}}.AppImage > defi-app-${{ env.PACKAGE_VERSION}}.AppImage.SHA256
+
       - name: Upload checksum - Linux
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
         with:
           upload_url: ${{ steps.latest_release_info.outputs.upload_url }}
           asset_path: ./defi-app-${{ env.PACKAGE_VERSION}}.AppImage.SHA256
@@ -65,7 +70,7 @@ jobs:
       APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: install dependencies
         run: npm cache clean --force && npm run init
@@ -83,27 +88,32 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
       - name: Get App Version
-        uses: nyaayaya/package-version@v1
+        uses: nyaayaya/package-version@05847b5b2b4e8cefeca8d50ee5940a6445a5773a
+
       - name: Fetch Release Asset
-        uses: Legion2/download-release-action@v2.1.0
+        uses: Legion2/download-release-action@68df3d242858e28a7e6d8b9838a3e6730cdfc422
         with:
           repository: 'DeFiCh/app'
           tag: 'v${{ env.PACKAGE_VERSION}}'
           file: 'defi-app-${{ env.PACKAGE_VERSION}}.dmg'
+
       - name: Get Release Info with Tag Name
         id: latest_release_info
-        uses: leahlundqvist/get-release@v1.3.1
+        uses: leahlundqvist/get-release@89e1ed4ad1c1951f278c6415dd6002bf0a992faf
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: 'v${{ env.PACKAGE_VERSION}}'
+
       - name: Generate SHA256 checksum
         run: |
           sha256sum defi-app-${{ env.PACKAGE_VERSION}}.dmg > defi-app-${{ env.PACKAGE_VERSION}}.dmg.SHA256
+
       - name: Upload checksum - Mac
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
         with:
           upload_url: ${{ steps.latest_release_info.outputs.upload_url }}
           asset_path: ./defi-app-${{ env.PACKAGE_VERSION}}.dmg.SHA256
@@ -116,7 +126,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: install dependencies
         run: npm cache clean --force && npm run init
@@ -134,27 +144,32 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
       - name: Get App Version
-        uses: nyaayaya/package-version@v1
+        uses: nyaayaya/package-version@05847b5b2b4e8cefeca8d50ee5940a6445a5773a
+
       - name: Fetch Release Asset
-        uses: Legion2/download-release-action@v2.1.0
+        uses: Legion2/download-release-action@68df3d242858e28a7e6d8b9838a3e6730cdfc422
         with:
           repository: 'DeFiCh/app'
           tag: 'v${{ env.PACKAGE_VERSION}}'
           file: 'defi-app-Setup-${{ env.PACKAGE_VERSION}}.exe'
+
       - name: Get Release Info with Tag Name
         id: latest_release_info
-        uses: leahlundqvist/get-release@v1.3.1
+        uses: leahlundqvist/get-release@89e1ed4ad1c1951f278c6415dd6002bf0a992faf
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: 'v${{ env.PACKAGE_VERSION}}'
+
       - name: Generate SHA256 checksum
         run: |
           sha256sum defi-app-Setup-${{ env.PACKAGE_VERSION}}.exe > defi-app-Setup-${{ env.PACKAGE_VERSION}}.exe.SHA256
+
       - name: Upload checksum - Windows
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
         with:
           upload_url: ${{ steps.latest_release_info.outputs.upload_url }}
           asset_path: ./defi-app-Setup-${{ env.PACKAGE_VERSION}}.exe.SHA256


### PR DESCRIPTION
Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

[docs.github.com/security-hardening-for-github-actions](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions)
[github.blog/collision-detection-on-github-com](https://github.blog/2017-03-20-sha-1-collision-detection-on-github-com/)

### Actions are pinned to these SHA
* https://github.com/actions/checkout/commits/5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
* https://github.com/actions/upload-artifact/commits/e448a9b857ee2131e752b06002bf0e093c65e571
* https://github.com/actions/upload-release-asset/commits/e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
* https://github.com/nyaa8/package-version/commits/05847b5b2b4e8cefeca8d50ee5940a6445a5773a
* https://github.com/Legion2/download-release-action/commits/68df3d242858e28a7e6d8b9838a3e6730cdfc422
* https://github.com/leahlundqvist/get-release/commits/89e1ed4ad1c1951f278c6415dd6002bf0a992faf

> Also updated/correct the spacing and indentations slightly, will add linting workflow in the future.