### PR TITLE
Removed masternode phantom footer space when there is no modal to show

### DIFF
--- a/webapp/src/containers/MasternodesPage/index.tsx
+++ b/webapp/src/containers/MasternodesPage/index.tsx
@@ -235,7 +235,13 @@ const MasternodesPage: React.FunctionComponent<MasternodesPageProps> = (
           />
         </section>
       </div>
-      <footer className='footer-bar'>
+      <footer
+        className={classnames({
+          'footer-bar': ['confirm', 'success', 'failure'].includes(
+            isConfirmationModalOpen
+          ),
+        })}
+      >
         <div
           className={classnames({
             'd-none': isConfirmationModalOpen !== 'confirm',


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/4266087/108306430-11814280-71e7-11eb-9506-313063123b7b.png)

## After
![image](https://user-images.githubusercontent.com/4266087/108306478-307fd480-71e7-11eb-8c8c-a202be710161.png)
