### PR TITLE
Run dev-builds only on PR to reduce concurrency cap

### DIFF
--- a/.github/workflows/dev-builds.yml
+++ b/.github/workflows/dev-builds.yml
@@ -1,11 +1,6 @@
 on:
-  push:
-    branches:
-      - 'ci/**'
-      - master
   pull_request:
-    branches:
-      - master
+    branches: [master]
 
 jobs:
   build_linux_version:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Due to increased GH Actions usage, limit CI jobs for dev-builds due to it's long running requests.

- 20 overall maximum concurrency for all jobs in ORG
- 5 for macOS

https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration

