### PR TITLE
included needs/logs & logs/accepted for issue triage ops

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,19 @@
 # Define individuals or teams that are responsible for code in a repository.
 # More details are here: https://help.github.com/articles/about-codeowners/
 
-/.github/                       @DeFiCh/admin
+/.github/                               @DeFiCh/admin
+/.github/oss-governance-bot.yml         @fuxingloh @izzycsy
+/.github/governance.yml                 @fuxingloh @izzycsy
 
-tslint.json                     @DeFiCh/admin
-tsconfig.json                   @DeFiCh/admin
-tsconfig.production.json        @DeFiCh/admin
+tslint.json                             @DeFiCh/admin
+tsconfig.json                           @DeFiCh/admin
+tsconfig.production.json                @DeFiCh/admin
 
-package.json                    @DeFiCh/admin
-package-lock.json               @DeFiCh/admin
+package.json                            @DeFiCh/admin
+package-lock.json                       @DeFiCh/admin
 
-*.sh                            @DeFiCh/admin
-*.cmd                           @DeFiCh/admin
-*.ps1                           @DeFiCh/admin
+*.sh                                    @DeFiCh/admin
+*.cmd                                   @DeFiCh/admin
+*.ps1                                   @DeFiCh/admin
 
-LICENSE                         @DeFiCh/admin
+LICENSE                                 @DeFiCh/admin

--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -53,6 +53,14 @@ issue:
       list: ['mac', 'win', 'linux']
       multiple: true
 
+    - prefix: logs
+      list: ['accepted', 'from-email']
+      multiple: true
+      author_association:
+        collaborator: true
+        member: true
+        owner: true
+
     - prefix: priority
       multiple: false
       list: ['urgent-now', 'important-soon']

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [master]
     paths:
-      - .github/labels.yml
+      # TODO(fuxingloh): delete/re-enable/migrate as it does not work well with version/* tags automation
+      - .github/labels-disabled.yml
 
 jobs:
   main:


### PR DESCRIPTION
#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

As requested by @izzycsy for issue triage logs workflow. 

```diff
    /needs logs
+   "needs/logs"
    User upload logs
    /logs accepted
-   "needs/logs"
+   "logs/accepted"
```

#### Additional notes
Also disabled `labels.yml` automation for now as it's not compatible with `governance.yml` auto version capturing.
https://github.com/DeFiCh/app/blob/55d753c945ceb633cd774059c1f69d97031bbef7/.github/governance.yml#L5-L8

CODEOWNERS has been updated so that it won't notify admin for `governance.yml` changes.
