### PR TITLE
fix footer backdrop

### DIFF
--- a/webapp/src/containers/WalletPage/components/SendPage/index.tsx
+++ b/webapp/src/containers/WalletPage/components/SendPage/index.tsx
@@ -499,7 +499,7 @@ class SendPage extends Component<SendPageProps, SendPageState> {
                 </InputGroup>
               </FormGroup>
               <div
-                className={`sendPage-backdrop ${this.state.showBackdrop}`}
+                className={`footer-backdrop ${this.state.showBackdrop}`}
                 onClick={this.sendStepDefault}
               />
             </Form>

--- a/webapp/src/scss/_layout.scss
+++ b/webapp/src/scss/_layout.scss
@@ -127,7 +127,7 @@ body {
       position: relative;
       z-index: $zindex-modal;
       padding: 16px 32px;
-      // background-color: $body-bg;
+      background-color: $dfi-scent;
       border-top: $border-width solid $border-color;
       border-bottom-left-radius: $border-radius * 1.5;
       width: 100%;
@@ -166,22 +166,6 @@ body {
     z-index: $zindex-modal-backdrop;
     width: 100%;
     height: 100%;
-    background-color: $modal-backdrop-bg;
-    opacity: $modal-backdrop-opacity;
-    display: none;
-
-    &.show-backdrop {
-      display: block;
-    }
-  }
-
-  .sendPage-backdrop {
-    position: absolute;
-    left: 0;
-    top: 0;
-    z-index: $zindex-modal-backdrop;
-    width: 100%;
-    height: 66.5vh;
     background-color: $modal-backdrop-bg;
     opacity: $modal-backdrop-opacity;
     display: none;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
/kind fix

#### What this PR does / why we need it:
Fixes visual issues backdrop/overlay behind the footer.

#### Which issue(s) does this PR fixes?:
Don't know. Just helping @saurabh391 

#### Additional comments?:
The problem I discovered is that `.footer-bar` does not have a `background-color` and thus the `.footer-backdrop` color shows through. Just needed to give `.footer-bar` a color of `$dfi-scent`. I also removed `.sendPage-backdrop` as we don’t need any specificity here.