### PR TITLE
upgraded oss-governance-bot to v2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,19 @@
 # Define individuals or teams that are responsible for code in a repository.
 # More details are here: https://help.github.com/articles/about-codeowners/
 
-/.github/                               @DeFiCh/admin
-/.github/oss-governance-bot.yml         @fuxingloh @izzycsy
-/.github/governance.yml                 @fuxingloh @izzycsy
+/.github/                                         @DeFiCh/admin
+/.github/workflows/oss-governance-bot.yml         @fuxingloh
+/.github/governance.yml                           @fuxingloh
 
-tslint.json                             @DeFiCh/admin
-tsconfig.json                           @DeFiCh/admin
-tsconfig.production.json                @DeFiCh/admin
+tslint.json                                       @DeFiCh/admin
+tsconfig.json                                     @DeFiCh/admin
+tsconfig.production.json                          @DeFiCh/admin
 
-package.json                            @DeFiCh/admin
-package-lock.json                       @DeFiCh/admin
+package.json                                      @DeFiCh/admin
+package-lock.json                                 @DeFiCh/admin
 
-*.sh                                    @DeFiCh/admin
-*.cmd                                   @DeFiCh/admin
-*.ps1                                   @DeFiCh/admin
+*.sh                                              @DeFiCh/admin
+*.cmd                                             @DeFiCh/admin
+*.ps1                                             @DeFiCh/admin
 
-LICENSE                                 @DeFiCh/admin
+LICENSE                                           @DeFiCh/admin

--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -129,7 +129,7 @@ pull_request:
           * `/kind refactor`
           * `/kind dependencies`
         status:
-          context: 'Governance / Kind'
+          context: 'Governance / Kind Label'
           description:
             success: Ready for review & merge.
             failure: Missing kind label for release generation.

--- a/.github/workflows/oss-governance-bot.yml
+++ b/.github/workflows/oss-governance-bot.yml
@@ -2,6 +2,7 @@ name: OSS
 
 on:
   pull_request_target:
+    branches: [master, main]
     types: [synchronize, opened, labeled, unlabeled]
   issues:
     types: [opened, labeled, unlabeled]
@@ -13,6 +14,6 @@ jobs:
     name: Governance
     runs-on: ubuntu-latest
     steps:
-      - uses: DeFiCh/oss-governance-bot@v1
+      - uses: DeFiCh/oss-governance-bot@v2
         with:
-          bot-token: ${{ secrets.DEFICHAIN_BOT_GITHUB_TOKEN }}
+          github-token: ${{ secrets.DEFICHAIN_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

Upgraded oss-governance-bot to v2 due to workflow automation chaining permission complications. Using a unified bot token now.

https://github.com/DeFiCh/oss-governance-bot/pull/64

