### PR TITLE
moved codeowners to individuals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,19 @@
 # Define individuals or teams that are responsible for code in a repository.
 # More details are here: https://help.github.com/articles/about-codeowners/
 
-/.github/                                         @DeFiCh/admin
+/.github/                                         @thedoublejay @fuxingloh @monstrobishi
 /.github/workflows/oss-governance-bot.yml         @fuxingloh
 /.github/governance.yml                           @fuxingloh
 
-tslint.json                                       @DeFiCh/admin
-tsconfig.json                                     @DeFiCh/admin
-tsconfig.production.json                          @DeFiCh/admin
+tslint.json                                       @thedoublejay @fuxingloh @monstrobishi
+tsconfig.json                                     @thedoublejay @fuxingloh @monstrobishi
+tsconfig.production.json                          @thedoublejay @fuxingloh @monstrobishi
 
-package.json                                      @DeFiCh/admin
-package-lock.json                                 @DeFiCh/admin
+package.json                                      @thedoublejay @fuxingloh @monstrobishi
+package-lock.json                                 @thedoublejay @fuxingloh @monstrobishi
 
-*.sh                                              @DeFiCh/admin
-*.cmd                                             @DeFiCh/admin
-*.ps1                                             @DeFiCh/admin
+*.sh                                              @thedoublejay @fuxingloh @monstrobishi
+*.cmd                                             @thedoublejay @fuxingloh @monstrobishi
+*.ps1                                             @thedoublejay @fuxingloh @monstrobishi
 
-LICENSE                                           @DeFiCh/admin
+LICENSE                                           @thedoublejay @fuxingloh @monstrobishi


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind chore

#### What this PR does / why we need it:

Moved CODEOWNERS to individuals instead of teams for better accountability and ownership of specified files.
