### PR TITLE
Enable rpc config for browser

### DIFF
--- a/webapp/src/app/service.tsx
+++ b/webapp/src/app/service.tsx
@@ -54,7 +54,11 @@ import { getNetworkType, getTimeDifferenceMS } from '../utils/utility';
 import { WalletMap } from '@defi_types/walletMap';
 import { REINDEX_NODE_UPDATE } from '@defi_types/settings';
 import { IPCResponseModel } from '../../../typings/common';
-import { PaymentRequestModel, RPCConfigItem } from '@defi_types/rpcConfig';
+import {
+  PaymentRequestModel,
+  RPCConfigItem,
+  RPCRemotes,
+} from '@defi_types/rpcConfig';
 import {
   getPaymentRequestsRPC,
   processWalletMapAddresses,
@@ -63,12 +67,43 @@ import { WalletState } from '../containers/WalletPage/types';
 
 export const getRpcConfig = () => {
   if (isElectron()) {
+    console.log('rpcconfig: electron');
     const ipcRenderer = ipcRendererFunc();
     return ipcRenderer.sendSync(GET_CONFIG_DETAILS, {});
+  } else if (typeof localStorage === 'object') {
+    // Environment with local storage
+    console.log('rpcconfig: localstorage');
+    return {
+      success: true,
+      data: JSON.parse(
+        localStorage.getItem('rpcconfig') ||
+          JSON.stringify(generateDefaultRpcRemotes())
+      ),
+    };
   }
-  // For webapp
+  // Fallback
+  console.log('rpcconfig: empty');
   return { success: true, data: {} };
 };
+
+function generateDefaultRpcRemotes(): RPCRemotes {
+  return {
+    remotes: [
+      {
+        rpcuser: 'user',
+        rpcpassword: 'pass',
+        rpcconnect: '127.0.0.1',
+        testnet: '1',
+        test: {
+          rpcport: '18555',
+        },
+        main: {
+          rpcport: '8555',
+        },
+      },
+    ],
+  };
+}
 
 export function startAppInit() {
   if (isElectron()) {


### PR DESCRIPTION
## What kind of PR is this?:

/kind feature

## What this PR does / why we need it:

### Summary 

This PR addresses a quick workaround to enable the webapp to run without the node from browsers reusing an existing node. 

### Details

It would be great to have the webapp run on it's own from the browser (without the features that require electron which are very very few like create / backup / restore wallets). This would not only enable exotic scenarios like hosting the node and serving the webapp as the interface to it remotely for private and personal networks within the context of secure devices, but I'd also expect make life so much easier for development without electron. 

While it would be ideal to have the pathways more streamlined in the code, this is not an absolutely necessity however - the current main blockers appear to be mainly just the following: 

1. The rpc config is empty in the browser context. Providing the proper config allows the rpc client to access the node. [This PR addresses this] 
2. CORS (This needs to be handled outside of this project, sadly - either by proxying the defichain node to include CORS headers or by other means)

#### Additional Details

- With the PR, the rpc client produces a default config just enough for the app to not throw invalid configuration errors on the browser that won't work without modification. 
-  The config can be set by adding the desired config to local storage with `localStorage.setItem('rpcconfig', { ..desiredconfig.. })` in the browser console and refreshing the app. 

### A better approach 

Ideally, the story would be even better if:

- The code paths are streamlined enough the the config can be passed as string on the command line to `npm run ...` and the starting config be picked up from there instead of localStorage, however this acts as a workaround in the meantime. 
- The `generateDefaultRpcRemotes` fn is refactored elsewhere such that it generates both this as well as the usual node's default config. 

That said, this accomplishes the same goal _as a workaround for now_ with least changes. 

#### Note: While it does allow it to work, this is still a hack, and not the cleanest way to support this - please feel free to ignore this PR if this doesn't align with the project.  