### PR TITLE
Add rpcallowip to default conf

### DIFF
--- a/electron-app/src/services/uiconfig.ts
+++ b/electron-app/src/services/uiconfig.ts
@@ -12,6 +12,7 @@ import {
 } from '../utils';
 import { APP_DIR, CONFIG_FILE_NAME } from '../constants';
 import {
+  DEFAULT_RPC_ALLOW_IP,
   DEFAULT_RPC_BIND,
   DEFAULT_RPC_PORT,
   RANDOM_USERNAME_LENGTH,
@@ -51,6 +52,7 @@ export default class UiConfig {
         rpcpassword,
         rpcbind: DEFAULT_RPC_BIND,
         rpcport: DEFAULT_RPC_PORT.toString(),
+        rpcallowip: DEFAULT_RPC_ALLOW_IP,
       };
       const configData = this.saveUiConfig(defaultConfig);
       return configData;

--- a/typings/rpcConfig.ts
+++ b/typings/rpcConfig.ts
@@ -3,6 +3,7 @@ export interface RPCConfigBody {
   rpcbind?: string;
   rpcport?: string;
   rpcconnect?: string;
+  rpcallowip?: string;
   testnet?: string;
   regtest?: string | RPCConfigBody;
   rpcuser?: string;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

### What kind of PR is this?:

/kind feature

### What this PR does / why we need it:

- Adds `rpcallowip` to the default defi.conf.
- This allows the `defid` binaries to be run for the same config without any flags like `nolisten` or `-rpcallow=`. 
- The doesn't affect the behavior of the wallet app since the command line argument overrides the conf file. 

### Additional Comments

- It might also be worth considering removing the command line argument that's passed to the node on start entirely since this allow advanced users to change this as desired and defi wallet app still work seamlessly. 