### PR TITLE
Use Auth header for RPC calls instead of clear text urls

### DIFF
--- a/webapp/src/utils/rpc-client.ts
+++ b/webapp/src/utils/rpc-client.ts
@@ -55,17 +55,18 @@ export default class RpcClient {
   client: any;
   constructor(cancelToken?) {
     const state = store.getState();
-    const { rpcauth, rpcconnect } = state.app.rpcConfig;
+    const { rpcuser, rpcpassword, rpcconnect } = state.app.rpcConfig;
     const activeNetwork = state.app.rpcConfig[state.app.activeNetwork];
     const rpcport = activeNetwork?.rpcport;
 
-    if (!rpcauth || !rpcconnect || !rpcport) {
+    if (!rpcuser || !rpcpassword || !rpcconnect || !rpcport) {
       throw new Error('Invalid configuration');
     }
     this.client = axios.create({
-      baseURL: `http://${rpcauth}@${rpcconnect}:${rpcport}`,
-      headers: {
-        'cache-control': 'no-cache',
+      baseURL: `http://${rpcconnect}:${rpcport}`,
+      auth: {
+        username: rpcuser,
+        password: rpcpassword,
       },
       cancelToken: cancelToken,
     });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:

Currently, the RPC calls are based on user and password in the URL. This leaves user names and password in clear text and as a part of the url, which is insecure. This changes the config for axios to use the Authorization header which is the recommended way to authorize with JSON RPC APIs.

Additionally, this PR also removes the `cache-control` headers. This is redundant since:

- defid RPC never adds cache control headers to it's responses. So, even in a browser context, this should be unnecessary. 
- Additionally, this can interfere with modern browser sandboxes like CORS and web security. 