### PR TITLE
Disable SPV

### DIFF
--- a/webapp/src/containers/MasternodesPage/saga.tsx
+++ b/webapp/src/containers/MasternodesPage/saga.tsx
@@ -139,7 +139,7 @@ export function* handleRestartNode() {
           masternode_operator: networkConf?.masternode_operator
             ? [...networkConf.masternode_operator, masternodeOperator]
             : [masternodeOperator],
-          spv: ENABLE_CONFIG,
+          spv: 0,
           gen: ENABLE_CONFIG,
         };
         yield put(restartModal());


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind chore

#### What this PR does / why we need it:

The anchoring reward breaks our newly included Merkle root safety check that comes with Eunos.

To allow the blockchain to proceed, all masternodes have to turn of Bitcoin SPV by setting spv=0 at defi.conf with immediate effect to mine a valid block.

For now, all anchors on Eunos will not be paid on time until a new upgrade cycle is set. Valid anchors that are accepted during Eunos will eventually be paid (deferred back payment) when the blockchain upgrade is in at a to-be-determined new block in the future.

If you are running masternode from the desktop app, a new build will be released by tomorrow that turns off SPV so you can mine valid blocks from the desktop app
