### PR TITLE
Token sorting: non-zero amounts first

### DIFF
--- a/webapp/src/containers/WalletPage/components/Balances/index.tsx
+++ b/webapp/src/containers/WalletPage/components/Balances/index.tsx
@@ -86,8 +86,12 @@ const BalancesPage: React.FunctionComponent = () => {
     });
     appTokens = (appTokens || []).filter((t) => !keys[t.hash]);
     clone = [...clone, ...appTokens]
-      .sort((a: IToken, b: IToken) => +a.hash - +b.hash)
-      .sort((a: IToken, b: IToken) => +a.isLPS - +b.isLPS)
+      .sort(
+        (a: IToken, b: IToken) =>
+          (a.amount ? -1 : 0) - (b.amount ? -1 : 0) ||
+          +a.isLPS - +b.isLPS ||
+          +a.hash - +b.hash
+      )
       .filter((t: IToken) => t.hash != DFI_SYMBOL);
 
     updateWalletToken(clone);


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind feature

#### What this PR does / why we need it:

This PR changes the order in which tokens are displayed:
* Primary criterion: Non-zero amounts come first
* Secondary criterion: DST before LP
* Tertiary: hash 

#### Which issue(s) does this PR fixes?:

Related to #1035

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
