### PR TITLE
moved snapshot folder into ~/.defi/

### DIFF
--- a/electron-app/src/utils.ts
+++ b/electron-app/src/utils.ts
@@ -334,5 +334,5 @@ export const deleteSnapshotFiles = () => {
 };
 
 export const getSnapshotFolder = (): string => {
-  return path.join(getBaseFolder(), '../', SNAPSHOT_FOLDER);
+  return path.join(getBaseFolder(), SNAPSHOT_FOLDER);
 };

--- a/electron-app/src/utils.ts
+++ b/electron-app/src/utils.ts
@@ -304,7 +304,7 @@ export const deleteSnapshotFolders = () => {
     const folders = getBlockchainFolders();
     folders.forEach((f) => {
       if (checkPathExists(f)) {
-        fs.rmdirSync(f, { recursive: true });
+        fs.rmSync(f, { recursive: true });
       }
     });
   } catch (error) {

--- a/electron-app/src/utils.ts
+++ b/electron-app/src/utils.ts
@@ -334,5 +334,8 @@ export const deleteSnapshotFiles = () => {
 };
 
 export const getSnapshotFolder = (): string => {
-  return path.join(getBaseFolder(), SNAPSHOT_FOLDER);
+  if (platform === LINUX) {
+    return path.join(getBaseFolder(), SNAPSHOT_FOLDER);
+  }
+  return path.join(getBaseFolder(), '../', SNAPSHOT_FOLDER);
 };


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:

This PR will move the snapshot folder into ~/.defi/ as opposed to before ~/snapshot
I think this is way more predictable as otherwise this might interfere with other programs on the host system.
Also it exchanges the deprecated rmdirSync() function for rmSync() (see https://nodejs.org/api/deprecations.html#DEP0147 )

#### Which issue(s) does this PR fixes?:

- #1072 

#### Additional comments?:

I tested the resulting .Appimage file on Arch Linux and everything works as expected.