### PR TITLE
chore(workflows): cleanup workflow permissions and names

### DIFF
--- a/.github/workflows/oss-governance-bot.yml
+++ b/.github/workflows/oss-governance-bot.yml
@@ -1,4 +1,4 @@
-name: OSS
+name: OSS Governance
 
 on:
   pull_request_target:
@@ -9,11 +9,15 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: write
+  checks: write
+
 jobs:
-  main:
-    name: Governance
+  Bot:
     runs-on: ubuntu-latest
     steps:
-      - uses: DeFiCh/oss-governance-bot@v2
-        with:
-          github-token: ${{ secrets.DEFICHAIN_BOT_GITHUB_TOKEN }}
+      - uses: BirthdayResearch/oss-governance-bot@23a023a59e633947923a299f0497371576e12e78

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,10 +4,18 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@349214e6b3b889d8b333c012cc61a1f1753baf40
+      - uses: release-drafter/release-drafter@e9ee02fbac03d922bac6212003695e8358dd88b0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

- Rename workflows related to "OSS Governance" into a single Workflow, renamed the job within to "Labels", "Labeler" and "Bot".
- Add `permissions:` for workflows to harden workflow security.
- Remov the use of `DEFICHAIN_BOT_GITHUB_TOKEN` for security hardening.
- Add `concurrency:` for workflows that requires it.
- Bump versions and migrate "OSS Governance Bot" to use the new org.